### PR TITLE
Paper Making and Fixes

### DIFF
--- a/config/ftbquests/quests/chapters/thermal_come_up_with_name_later.snbt
+++ b/config/ftbquests/quests/chapters/thermal_come_up_with_name_later.snbt
@@ -259,6 +259,28 @@
 			x: 11.5d
 			y: 1.5d
 		}
+		{
+			dependencies: ["5403827F2BD5C6DB"]
+			id: "71376344CC69E13D"
+			tasks: [{
+				id: "38C989E4EA4EA0AD"
+				item: "minecraft:paper"
+				type: "item"
+			}]
+			x: -0.5d
+			y: -1.5d
+		}
+		{
+			dependencies: ["4545A2E4754072D3"]
+			id: "1334D98DDBF3575A"
+			tasks: [{
+				id: "715F4EA24D549F57"
+				item: "gtceu:lv_machine_hull"
+				type: "item"
+			}]
+			x: 15.0d
+			y: 1.5d
+		}
 	]
 	title: "Thermal (come up with name later)"
 }

--- a/config/ftbquests/quests/chapters/thermal_come_up_with_name_later.snbt
+++ b/config/ftbquests/quests/chapters/thermal_come_up_with_name_later.snbt
@@ -261,6 +261,7 @@
 		}
 		{
 			dependencies: ["5403827F2BD5C6DB"]
+			description: ["You can make paper 2 ways: find sugar cane, grind it into chad then press into Paper, or throw wood pulp into water to make chad and then press into Paper"]
 			id: "71376344CC69E13D"
 			tasks: [{
 				id: "38C989E4EA4EA0AD"
@@ -272,6 +273,7 @@
 		}
 		{
 			dependencies: ["4545A2E4754072D3"]
+			description: ["LV time baybeeeee"]
 			id: "1334D98DDBF3575A"
 			tasks: [{
 				id: "715F4EA24D549F57"

--- a/kubejs/server_scripts/Misc.js
+++ b/kubejs/server_scripts/Misc.js
@@ -32,4 +32,13 @@ ServerEvents.recipes(event => {
                      '2x gtceu:hematite_dust')
         .duration(6000).EUt(30)
         .circuit(9)
+
+    //Treated Wood Pulverization
+    event.recipes.thermal.pulverizer(['gtceu:treated_wood_dust'], ['gtceu:treated_wood_planks'])
+    event.recipes.thermal.pulverizer(['gtceu:treated_wood_dust'], ['gtceu:treated_wood_plate'])
+    event.recipes.thermal.pulverizer(['gtceu:treated_wood_dust'], ['gtceu:treated_wood_door'])
+    event.recipes.thermal.pulverizer(['gtceu:treated_wood_dust'], ['gtceu:treated_wood_small_fluid_pipe'])
+    event.recipes.thermal.pulverizer(['3x gtceu:treated_wood_dust'], ['gtceu:treated_wood_frame'])
+    event.recipes.thermal.pulverizer(['3x gtceu:treated_wood_dust'], ['gtceu:treated_wood_normal_fluid_pipe'])
+    event.recipes.thermal.pulverizer(['6x gtceu:treated_wood_dust'], ['gtceu:treated_wood_large_fluid_pipe'])
 })

--- a/kubejs/server_scripts/Yeeter.js
+++ b/kubejs/server_scripts/Yeeter.js
@@ -77,7 +77,11 @@ const items = [
                     'thermal:deep_aquachow',
                     'ae2:facade',
                     'gtceu:steam_miner',
-                    'gtceu:primitive_blast_furnace'
+                    'gtceu:primitive_blast_furnace',
+                    'thermal:press_gear_die',
+                    'thermal:press_packing_2x2_die',
+                    'thermal:press_packing_3x3_die',
+                    'thermal:press_unpacking_die',
 ]            
 const fluids = [
                     'thermal:redstone',

--- a/kubejs/server_scripts/mod_specific/Thermal.js
+++ b/kubejs/server_scripts/mod_specific/Thermal.js
@@ -109,6 +109,24 @@ ServerEvents.recipes(event => {
     event.recipes.thermal.press('2x gtceu:lead_plate', '3x gtceu:lead_ingot')  
     event.recipes.thermal.press('2x gtceu:steel_plate', '3x gtceu:steel_ingot')
     event.recipes.thermal.press('2x gtceu:iron_plate', '3x gtceu:tin_ingot')
-    event.recipes.thermal.press('2x gtceu:copper_plate', '3x minecraft:ingot_ingot')
     event.recipes.thermal.press('2x gtceu:red_alloy_plate', '3x gtceu:red_alloy_ingot')
+
+    //REPLACE TIME
+    event.replaceInput(
+        { input: 'thermal:press_packing_3x3_die' }, 
+        'thermal:press_packing_3x3_die',           
+        'gtceu:block_casting_mold'         
+      )
+
+    event.replaceInput(
+        { input: 'thermal:press_packing_2x2_die' }, 
+        'thermal:press_packing_2x2_die',           
+        'gtceu:block_casting_mold'         
+      )
+
+    event.replaceInput(
+        { input: 'thermal:press_unpacking_die' }, 
+        'thermal:press_unpacking_die',           
+        'gtceu:ingot_casting_mold'         
+      )
 })

--- a/kubejs/server_scripts/tier_specific/ULV.js
+++ b/kubejs/server_scripts/tier_specific/ULV.js
@@ -151,6 +151,9 @@ ServerEvents.recipes(event => {
         }
     )
 
+    //Treated Wood Plank Recipes
+    event.recipes.thermal.press('gtceu:treated_wood_plate', ['gtceu:treated_wood_dust'])
+
     event.shapeless('2x gtceu:clay_plate', ['#forge:tools/hammers', 'minecraft:clay']).id('omega:shapeless/clay_plate')
     event.shapeless('kubejs:unfired_ball_cast', ['#forge:tools/mallets', 'gtceu:clay_plate']).id('omega:shapeless/unfired_ball_cast')
     
@@ -173,4 +176,15 @@ ServerEvents.recipes(event => {
     
     event.recipes.thermal.smelter(['kubejs:hot_wrought_iron_ingot', 'gtceu:dark_ash_dust'], ['minecraft:iron_ingot'])
     event.recipes.thermal.press('gtceu:wrought_iron_ingot', ['kubejs:hot_wrought_iron_ingot'])
+
+    //ULV Paper
+    event.custom({
+        "type": 'ae2:transform',
+        "circumstance": { "type": 'fluid', "tag": 'minecraft:water' },
+        "ingredients": [
+          { "item": 'gtceu:wood_dust' }, ],
+        "result": { "count": 1, "item": 'gtceu:paper_dust' }
+    }).id('omega:transformation/paper_dust')
+
+    event.recipes.thermal.press('minecraft:paper', ['gtceu:paper_dust'])
 })


### PR DESCRIPTION
- Adds recipe for Paper in the Multiservo Press using Chad
- Also adds in-world conversion of Wood Pulp into Chad
- Replaced the rest of the packing dies with GT molds, somewhat addresses their issues in #8 
- Yeeted packing dies
- Added way to make Treated Wood Planks in ULV via adding recipes to Pulverizer and Multiservo Press
- Added new quests for LV Machine Hulls and Paper